### PR TITLE
Implement lobby auto-expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,11 @@ A Discord game lobby butler that makes it easy to gather players for any game, r
   - **Join** / **Leave** buttons on each lobby embed for one-click roster management.  
   - Embed updates in real time as players join or leave.
 
-- **Auto-ping when full**  
+- **Auto-ping when full**
   - As soon as the player count reaches the lobby size, Lobert posts a “🚀 Lobby full!” message tagging everyone in that lobby.
+
+- **Auto-expire**
+  - Lobbies automatically close and their message is removed after 3 hours.
 
 - **Multi-lobby support**  
   - Handle multiple lobbies across different games (or the same game) simultaneously.

--- a/dist/commands/lobby.js
+++ b/dist/commands/lobby.js
@@ -54,6 +54,7 @@ function execute(interaction) {
                 game,
                 size,
                 players: [interaction.user.id],
+                expiresAt: Date.now() + 3 * 60 * 60 * 1000,
             });
             /* --- replace temp IDs with the real message ID (TS‑safe casts) --- */
             const fixedRow = discord_js_1.ActionRowBuilder.from(tempRow);

--- a/dist/index.js
+++ b/dist/index.js
@@ -45,6 +45,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.client = void 0;
 const discord_js_1 = require("discord.js");
 const dotenv = __importStar(require("dotenv"));
 const node_fs_1 = __importDefault(require("node:fs"));
@@ -54,8 +55,8 @@ dotenv.config(); // loads DISCORD_TOKEN, CLIENT_ID, GUILD_ID
 /* ------------------------------------------------------------------ */
 /* 2. Instantiate client and commands collection                      */
 /* ------------------------------------------------------------------ */
-const client = new discord_js_1.Client({ intents: [discord_js_1.GatewayIntentBits.Guilds] });
-client.commands = new discord_js_1.Collection();
+exports.client = new discord_js_1.Client({ intents: [discord_js_1.GatewayIntentBits.Guilds] });
+exports.client.commands = new discord_js_1.Collection();
 /* ------------------------------------------------------------------ */
 /* 3. Load command modules (.js in production, .ts in dev)             */
 /* ------------------------------------------------------------------ */
@@ -65,16 +66,16 @@ const commandFiles = node_fs_1.default
     .filter((file) => file.endsWith('.js') || file.endsWith('.ts'));
 for (const file of commandFiles) {
     const command = require(node_path_1.default.join(commandsPath, file));
-    client.commands.set(command.data.name, command);
+    exports.client.commands.set(command.data.name, command);
 }
-console.log('Loaded commands:', [...client.commands.keys()]);
+console.log('Loaded commands:', [...exports.client.commands.keys()]);
 /* ------------------------------------------------------------------ */
 /* 4. Event handlers                                                   */
 /* ------------------------------------------------------------------ */
-client.once(discord_js_1.Events.ClientReady, (bot) => {
+exports.client.once(discord_js_1.Events.ClientReady, (bot) => {
     console.log(`🤖 Logged in as ${bot.user.tag}`);
 });
-client.on(discord_js_1.Events.InteractionCreate, (interaction) => __awaiter(void 0, void 0, void 0, function* () {
+exports.client.on(discord_js_1.Events.InteractionCreate, (interaction) => __awaiter(void 0, void 0, void 0, function* () {
     // Handle buttons
     if (interaction.isButton()) {
         yield handleButton(interaction);
@@ -82,7 +83,7 @@ client.on(discord_js_1.Events.InteractionCreate, (interaction) => __awaiter(void
     }
     // Handle slash commands
     if (interaction.isChatInputCommand()) {
-        const command = client.commands.get(interaction.commandName);
+        const command = exports.client.commands.get(interaction.commandName);
         if (!command)
             return;
         try {
@@ -124,9 +125,7 @@ function handleButton(interaction) {
             embed.description = lobby.players.map((id) => `<@${id}>`).join('\n') || '*Empty*';
             yield msg.edit({ embeds: [embed] });
             if (lobby.players.length === lobby.size && (channel === null || channel === void 0 ? void 0 : channel.isTextBased())) {
-                // Tell TS this is a TextBasedChannel so .send() is valid:
-                const textCh = channel;
-                yield textCh.send(`🚀  Lobby full! ${lobby.players.map((id) => `<@${id}>`).join(' ')}`);
+                yield channel.send(`🚀  Lobby full! ${lobby.players.map((id) => `<@${id}>`).join(' ')}`);
             }
         }
         catch (error) {
@@ -137,4 +136,4 @@ function handleButton(interaction) {
 /* ------------------------------------------------------------------ */
 /* 5. Login                                                           */
 /* ------------------------------------------------------------------ */
-client.login(process.env.DISCORD_TOKEN);
+exports.client.login(process.env.DISCORD_TOKEN);

--- a/dist/lib/LobbyManager.js
+++ b/dist/lib/LobbyManager.js
@@ -1,4 +1,46 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
 var __classPrivateFieldGet = (this && this.__classPrivateFieldGet) || function (receiver, state, kind, f) {
     if (kind === "a" && !f) throw new TypeError("Private accessor was defined without a getter");
     if (typeof state === "function" ? receiver !== state || !f : !state.has(receiver)) throw new TypeError("Cannot read private member from an object whose class did not declare it");
@@ -14,6 +56,19 @@ class LobbyManager {
     }
     create(lobby) {
         __classPrivateFieldGet(this, _LobbyManager_lobbies, "f").set(lobby.id, lobby);
+        setTimeout(() => __awaiter(this, void 0, void 0, function* () {
+            this.delete(lobby.id);
+            try {
+                const { client } = yield Promise.resolve().then(() => __importStar(require('../index')));
+                const channel = yield client.channels.fetch(lobby.channelId);
+                if (channel === null || channel === void 0 ? void 0 : channel.isTextBased()) {
+                    channel.messages.delete(lobby.id).catch(() => null);
+                }
+            }
+            catch (_a) {
+                // ignore
+            }
+        }), 3 * 60 * 60 * 1000);
     }
     get(id) {
         return __classPrivateFieldGet(this, _LobbyManager_lobbies, "f").get(id);

--- a/src/commands/lobby.ts
+++ b/src/commands/lobby.ts
@@ -62,6 +62,7 @@ import {
         game,
         size,
         players: [interaction.user.id],
+        expiresAt: Date.now() + 3 * 60 * 60 * 1000,
       });
   
       /* --- replace temp IDs with the real message ID (TS‑safe casts) --- */

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ interface LobertClient extends Client<boolean> {
 /* ------------------------------------------------------------------ */
 /* 2. Instantiate client and commands collection                      */
 /* ------------------------------------------------------------------ */
-const client = new Client({ intents: [GatewayIntentBits.Guilds] }) as LobertClient;
+export const client = new Client({ intents: [GatewayIntentBits.Guilds] }) as LobertClient;
 client.commands = new Collection<string, Command>();
 
 /* ------------------------------------------------------------------ */
@@ -102,9 +102,7 @@ async function handleButton(interaction: ButtonInteraction) {
     await msg.edit({ embeds: [embed] });
 
     if (lobby.players.length === lobby.size && channel?.isTextBased()) {
-      // Tell TS this is a TextBasedChannel so .send() is valid:
-      const textCh = channel as TextBasedChannel;
-      await textCh.send(
+      await (channel as any).send(
         `🚀  Lobby full! ${lobby.players.map((id) => `<@${id}>`).join(' ')}`
       );
     }


### PR DESCRIPTION
## Summary
- expire lobbies after 3 hours
- delete lobby message when timeout triggers
- record expiration time when creating lobby
- export `client` to allow LobbyManager cleanup
- document auto-expire feature
- rebuild compiled JavaScript

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c1fb4420c8325bba732c3ca5e6899