### PR TITLE
Implement enhanced lobby listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,4 +96,5 @@ Maintained by
 ---
 
 ## Dev's To-do list of Features & Bug-fixes
-- Modify the /lobby list command so that it publically(not just the "only you can see this" messages) prints out all the opened lobbies' embed with the join/leave buttons instead of just a list. (People need to keep scrolling up to find the embed and click join/leave)
+- ~~Modify the /lobby list command so that it publically(not just the "only you can see this" messages) prints out all the opened lobbies' embed with the join/leave buttons instead of just a list. (People need to keep scrolling up to find the embed and click join/leave)~~
+  - Done: `/lobby list` now republishes each lobby's embed with join/leave buttons in the channel.

--- a/dist/commands/lobby.js
+++ b/dist/commands/lobby.js
@@ -69,8 +69,25 @@ function execute(interaction) {
             if (!open.length) {
                 return interaction.reply({ content: 'No open lobbies.', ephemeral: true });
             }
-            const lines = open.map(l => `• **${l.game}**  (${l.players.length}/${l.size}) – <@${l.creatorId}>`);
-            yield interaction.reply({ content: lines.join('\n'), ephemeral: true });
+            for (const [i, lobby] of open.entries()) {
+                const channel = yield interaction.client.channels.fetch(lobby.channelId);
+                if (!(channel === null || channel === void 0 ? void 0 : channel.isTextBased()))
+                    continue;
+                try {
+                    const msg = yield channel.messages.fetch(lobby.id);
+                    const embed = msg.embeds[0];
+                    const components = msg.components;
+                    if (i === 0) {
+                        yield interaction.reply({ embeds: [embed], components });
+                    }
+                    else {
+                        yield interaction.followUp({ embeds: [embed], components });
+                    }
+                }
+                catch (_a) {
+                    /* message may be gone */
+                }
+            }
         }
         /* ──────────────── CANCEL ──────────────── */
         else if (sub === 'cancel') {

--- a/dist/index.js
+++ b/dist/index.js
@@ -124,9 +124,7 @@ function handleButton(interaction) {
             embed.description = lobby.players.map((id) => `<@${id}>`).join('\n') || '*Empty*';
             yield msg.edit({ embeds: [embed] });
             if (lobby.players.length === lobby.size && (channel === null || channel === void 0 ? void 0 : channel.isTextBased())) {
-                // Tell TS this is a TextBasedChannel so .send() is valid:
-                const textCh = channel;
-                yield textCh.send(`🚀  Lobby full! ${lobby.players.map((id) => `<@${id}>`).join(' ')}`);
+                yield channel.send(`🚀  Lobby full! ${lobby.players.map((id) => `<@${id}>`).join(' ')}`);
             }
         }
         catch (error) {

--- a/src/commands/lobby.ts
+++ b/src/commands/lobby.ts
@@ -83,9 +83,23 @@ import {
       if (!open.length) {
         return interaction.reply({ content: 'No open lobbies.', ephemeral: true });
       }
-      const lines = open.map(l =>
-        `• **${l.game}**  (${l.players.length}/${l.size}) – <@${l.creatorId}>`);
-      await interaction.reply({ content: lines.join('\n'), ephemeral: true });
+
+      for (const [i, lobby] of open.entries()) {
+        const channel = await interaction.client.channels.fetch(lobby.channelId);
+        if (!channel?.isTextBased()) continue;
+        try {
+          const msg = await channel.messages.fetch(lobby.id);
+          const embed = msg.embeds[0];
+          const components = msg.components;
+          if (i === 0) {
+            await interaction.reply({ embeds: [embed], components });
+          } else {
+            await interaction.followUp({ embeds: [embed], components });
+          }
+        } catch {
+          /* message may be gone */
+        }
+      }
     }
   
     /* ──────────────── CANCEL ──────────────── */

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,9 +102,7 @@ async function handleButton(interaction: ButtonInteraction) {
     await msg.edit({ embeds: [embed] });
 
     if (lobby.players.length === lobby.size && channel?.isTextBased()) {
-      // Tell TS this is a TextBasedChannel so .send() is valid:
-      const textCh = channel as TextBasedChannel;
-      await textCh.send(
+      await (channel as any).send(
         `🚀  Lobby full! ${lobby.players.map((id) => `<@${id}>`).join(' ')}`
       );
     }


### PR DESCRIPTION
## Summary
- show lobby embeds with join/leave buttons when running `/lobby list`
- adjust full lobby message send
- update README to mark improvement complete

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c19ba2eec8325811c53d8367b0f2c